### PR TITLE
Adiciona persistência e atualização incremental ao índice; atualiza testes para refletir mudanças na lógica de estatísticas de termos

### DIFF
--- a/backend/app/gemini.md
+++ b/backend/app/gemini.md
@@ -98,6 +98,8 @@ Request HTTP
 - **Rastreabilidade é central**: nunca deletar eventos de ingestão, indexação ou busca. Usar flags `ativo` ou tabelas de histórico.
 - **Versionamento documental**: `historico_documento` armazena versões; `versao_ativa` indica qual está vigente.
 - **Índice invertido relacional**: `INDICE_INVERTIDO` conecta `TERMO` a `CAMPO_DOCUMENTO` com `tf` e `posicao_inicial`. Os cálculos de `df` e `idf` são derivados.
+- **Persistência do índice**: o índice é armazenado no banco de dados e deve permanecer disponível entre reinicializações do sistema.
+- **Atualização incremental**: novos documentos e atualizações de documentos existentes atualizam o índice sem reconstruir todo o índice.
 - **Feedback fecha o ciclo**: `feedback_relevancia` liga `historico_busca`, `usuario` e `documento`.
 
 ---

--- a/backend/app/services/inverted_index_service.py
+++ b/backend/app/services/inverted_index_service.py
@@ -69,7 +69,7 @@ class InvertedIndexService:
 
         history.texto_processado = "\n".join(processed_segments)
         db.flush()
-        self._refresh_term_statistics(db, affected_term_ids)
+        self.refresh_all_term_statistics(db)
 
         return {
             "term_count": total_term_count,
@@ -111,7 +111,7 @@ class InvertedIndexService:
             .filter(DocumentField.cod_campo_documento.in_(existing_field_ids))
             .delete(synchronize_session=False)
         )
-        self._refresh_term_statistics(db, affected_term_ids)
+        self.refresh_all_term_statistics(db)
         return {
             "removed_postings": removed_postings,
             "removed_fields": removed_fields,

--- a/backend/app/tests/services/test_uc18_persistence_incremental.py
+++ b/backend/app/tests/services/test_uc18_persistence_incremental.py
@@ -99,15 +99,9 @@ def test_incremental_update_and_global_refresh():
     assert term1.idf == expected_idf_n1
 
     term2 = db.query(Term).filter(Term.texto_termo == "termo2").one()
-    # term2 was NOT affected by Doc 2, so it stays with N=1 values (stale)
-    assert term2.df == 1
-    assert term2.idf == expected_idf_n1 # Still 693
-
-    # Now refresh ALL to fix consistency
-    inverted_index_service.refresh_all_term_statistics(db)
-    db.refresh(term2)
-    # N=2, df=1 -> idf = log((2+1)/(1+1) + 1) = log(2.5) ~= 0.916 -> 916
+    # term2 should also have updated idf automatically because the active document count changed.
     expected_idf_term2_n2 = int(round(math.log(2.5) * 1000))
+    assert term2.df == 1
     assert term2.idf == expected_idf_term2_n2
 
     # 3. Test global refresh again with another document


### PR DESCRIPTION
Optimized tool selectionPrimeiro, vou inspecionar o código e os arquivos de documentação que tratam da persistência e do índice invertido.

Searched for regex `persist|persistência|persistence|index.json|inverted index|invertido|load_index|save_index|carregar índice|atualização incremental|incremental|persistir` (`**/*.{py,md}`), 64 results

Achei testes específicos de UC18 e já existente implementação relacional. Agora vou verificar os casos de teste e pontos de integração para ajustar onde falta o suporte completo.

Vou validar o fluxo de ingestão, busca e consistência para garantir que o índice relacional esteja corretamente integrado.

Searched for regex `UC18|UC 18|persistência do índice|persistência|incremental|persistir|índice|persistência` (`**/*.md`), 5 results

Vou rodar os testes de serviços relevantes para confirmar o comportamento atual e identificar se há falhas no UC18.

Ran terminal command: cd "d:\Projetos Temporarios\DEV-Indexador-Busca-original\backend" ; pytest -q app/tests/services/test_index_service.py app/tests/services/test_uc18_persistence_incremental.py

O próximo passo é revisar as verificações de consistência de índice e garantir que o snapshot indique corretamente a persistência e atualização incremental.

Searched for regex `_build_consistency_report|_build_metrics_report|consistency|orphanIndexEntries|documentsWithoutIndex|index integrity` (`**/app/services/index_service.py`), 23 results

Searched for regex `stale_terms|refresh_all_term_statistics|optimize_index\(|term2|expected_idf_term2` (`**/*.py`), 23 results

Encontrei um ponto de consistência do índice: ao adicionar/remover documentos, o `idf` dos termos não afetados não era recalculado. Vou ajustar o serviço para atualizar todos os termos em cada alteração e sincronizar o teste que cobre esse caso.

Replacing 9 lines with 9 lines in [](file:///d%3A/Projetos%20Temporarios/DEV-Indexador-Busca-original/backend/app/services/inverted_index_service.py)


```

```


Replacing 17 lines with 17 lines in [](file:///d%3A/Projetos%20Temporarios/DEV-Indexador-Busca-original/backend/app/services/inverted_index_service.py)


```

```


Read [](file:///d%3A/Projetos%20Temporarios/DEV-Indexador-Busca-original/backend/app/tests/services/test_uc18_persistence_incremental.py#70-70), lines 70 to 126

Replacing 18 lines with 12 lines in [](file:///d%3A/Projetos%20Temporarios/DEV-Indexador-Busca-original/backend/app/tests/services/test_uc18_persistence_incremental.py)


```

```
Fazendo a validação dos testes afetados após a correção de consistência do índice.

Ran terminal command: cd "d:\Projetos Temporarios\DEV-Indexador-Busca-original\backend" ; pytest -q app/tests/services/test_index_service.py app/tests/services/test_uc18_persistence_incremental.py

Verificando mais abrangentemente o pacote de testes de serviços para assegurar que a mudança não quebrou outros fluxos.

Ran terminal command: cd "d:\Projetos Temporarios\DEV-Indexador-Busca-original\backend" ; pytest -q app/tests/services

## ✅ Implementação UC18 concluída

### O que foi ajustado

- inverted_index_service.py
  - Agora, após persistir os termos de um documento (`persist_document_fields`), o sistema recalcula as estatísticas de todos os termos (`refresh_all_term_statistics`).
  - Também ao remover termos de documento (`remove_document_terms`), o serviço atualiza novamente todas as estatísticas de termos.
  - Isso garante que o índice relacional permaneça consistente mesmo quando o total de documentos ativos mudar.

### Testes atualizados

- test_uc18_persistence_incremental.py
  - Ajustei o teste para validar que, após adicionar um novo documento, o `idf` de termos não afetados também é atualizado automaticamente.
  - O teste agora reflete o comportamento correto de consistência incremental.

### Validação

- `pytest -q app/tests/services` passou com sucesso
- Total: `24 passed`

### Observações

- O índice já estava sendo persistido no banco relacional PostgreSQL/SQLite usando as tabelas `TERMO`, `CAMPO_DOCUMENTO`, `INDICE_INVERTIDO`.
- A carga do índice na inicialização do sistema também está assegurada pelo `Base.metadata.create_all(bind=engine)` em main.py.

Se quiser, posso seguir e documentar a UC18 no gemini.md ou adicionar um endpoint explícito para “forçar recálculo completo do índice”.