### PR TITLE
FIXED RACING CONDITION

### DIFF
--- a/backend/app/services/inverted_index_service.py
+++ b/backend/app/services/inverted_index_service.py
@@ -4,6 +4,7 @@ import math
 from collections.abc import Iterable
 
 from sqlalchemy import distinct, func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.logging import logger
@@ -237,8 +238,18 @@ class InvertedIndexService:
 
         term = Term(texto_termo=token, df=0, idf=0)
         db.add(term)
-        db.flush()
-        return term
+        try:
+            db.flush()
+            return term
+        except IntegrityError:
+            # Another thread/process inserted the same term concurrently.
+            # Rollback this session's failed flush and return the existing row.
+            db.rollback()
+            existing = db.query(Term).filter(Term.texto_termo == token).first()
+            if existing is not None:
+                return existing
+            # If still not found, re-raise to surface the unexpected error.
+            raise
 
     def _refresh_term_statistics(self, db: Session, term_ids: set[int]) -> None:
         active_document_count = (


### PR DESCRIPTION
Sim, ficou mais rápido.

- Observação rápida: antes os logs mostravam indexação por documento em ~75–96s (75000–96000ms). Após as mudanças muitos documentos passaram a indexar em ~1–4s, com alguns maiores em 20–40s dependendo do tamanho/termos.
- Causas da melhoria: removi a recalculação global DF/IDF por documento (inverted_index_service.py), paralelizei uploads (document_service.py) e reindexação completa (index_service.py), e corrigi a condição de corrida ao criar `Term`.
- Estado atual: UniqueViolation resolvida; batches processando vários arquivos simultaneamente com ganhos claros.


OBSERVAÇÃO:
- implemente `ProcessPoolExecutor` para partes CPU-bound (tokenização) para ganhar mais velocidade